### PR TITLE
Update IIS CPEs

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -12,7 +12,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows NT"/>
@@ -27,7 +27,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:5.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
@@ -41,7 +41,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -55,7 +55,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -69,7 +69,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -189,7 +189,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:7.*"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -203,7 +203,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:8.*"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -219,7 +219,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -233,7 +233,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -302,7 +302,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="service.component.vendor" value="Microsoft"/>
     <param pos="0" name="service.component.family" value="ASP.NET"/>
     <param pos="0" name="service.component.product" value="ASP.NET"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -186,7 +186,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows NT"/>
@@ -201,7 +201,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:5.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
@@ -215,7 +215,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.1"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.1"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:5.1"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
@@ -229,7 +229,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="6.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:6.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:6.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
@@ -243,7 +243,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:7.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -257,7 +257,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:7.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -271,7 +271,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:8.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
@@ -285,7 +285,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:8.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
@@ -299,7 +299,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="10.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:10.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:10.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.certainty" value="0.5"/>
@@ -312,7 +312,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Microsoft-IIS$">
@@ -321,7 +321,7 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -30,7 +30,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
@@ -46,7 +46,7 @@
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -268,7 +268,7 @@
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="1" name="host.name"/>
     <param pos="3" name="system.time"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
@@ -285,7 +285,7 @@
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="1" name="host.name"/>
     <param pos="3" name="system.time"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
@@ -302,7 +302,7 @@
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="3" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="system.time"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
@@ -323,7 +323,7 @@
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:internet_information_services:{service.version}"/>
     <param pos="1" name="host.name"/>
     <param pos="3" name="system.time"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>


### PR DESCRIPTION
## Description

The `iis` product field has now been deprecated in favor of `internet_information_systems`. See the [NVD search page](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Amicrosoft%3Ainternet_information_services%3A7.*) for examples.

Also, using major versions like `7` instead of `7.*` breaks [searching](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Amicrosoft%3Ainternet_information_services%3A7).

## How Has This Been Tested?

```
bundle exec rspec spec/lib/fingerprint_self_test_spec.rb -E 'IIS'
```